### PR TITLE
feat: add mobile view selector for dashboard sections

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -259,6 +259,11 @@
 	margin-top: 40px; /* Added from App.tsx inline style */
 }
 
+.app-main-content.mobile {
+	flex-direction: column;
+	margin-top: 0;
+}
+
 .app-legend {
 	display: flex;
 	justify-content: center;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,16 +1,21 @@
 import './App.css';
 
-import { Legend, TimeDisplay } from './common/index.ts';
-import { RacesContainer } from './race/index.ts';
+import { Legend, TimeDisplay, ViewSelector } from './common/index.ts';
+import { CurrentRaceView, NextRacesView, RacesContainer } from './race/index.ts';
 import SnapshotControl from './devTools/SnapshotControl.tsx';
 import { useIdleCursor } from './common/useIdleCursor.ts';
 import { Leaderboard } from './leaderboard/Leaderboard.tsx';
-import { EliminatedPilotsView } from './bracket/index.ts';
+import { BracketsView, EliminatedPilotsView } from './bracket/index.ts';
 import { GenericSuspense } from './common/GenericSuspense.tsx';
+import { useAtomValue } from 'jotai';
+import useBreakpoint from './responsive/useBreakpoint.ts';
+import { activePaneAtom } from './state/viewAtoms.ts';
 
 function App() {
 	// Use the custom hook to handle cursor visibility
 	useIdleCursor();
+	const { isMobile } = useBreakpoint();
+	const activePane = useAtomValue(activePaneAtom);
 
 	return (
 		<>
@@ -23,16 +28,51 @@ function App() {
 					<TimeDisplay />
 				</GenericSuspense>
 			</div>
-			<div className='app-main-content'>
-				<GenericSuspense id='races-container'>
-					<RacesContainer />
-				</GenericSuspense>
-				<GenericSuspense id='leaderboard'>
-					<Leaderboard />
-				</GenericSuspense>
-				<GenericSuspense id='eliminated-pilots-view'>
-					<EliminatedPilotsView />
-				</GenericSuspense>
+			{isMobile && <ViewSelector />}
+			<div className={'app-main-content' + (isMobile ? ' mobile' : '')}>
+				{isMobile
+					? (
+						<>
+							{activePane === 'leaderboard' && (
+								<GenericSuspense id='leaderboard'>
+									<Leaderboard />
+								</GenericSuspense>
+							)}
+							{activePane === 'current' && (
+								<GenericSuspense id='current-race'>
+									<CurrentRaceView />
+								</GenericSuspense>
+							)}
+							{activePane === 'next' && (
+								<GenericSuspense id='next-races'>
+									<NextRacesView />
+								</GenericSuspense>
+							)}
+							{activePane === 'brackets' && (
+								<GenericSuspense id='brackets'>
+									<BracketsView />
+								</GenericSuspense>
+							)}
+							{activePane === 'eliminated' && (
+								<GenericSuspense id='eliminated-pilots-view'>
+									<EliminatedPilotsView />
+								</GenericSuspense>
+							)}
+						</>
+					)
+					: (
+						<>
+							<GenericSuspense id='races-container'>
+								<RacesContainer />
+							</GenericSuspense>
+							<GenericSuspense id='leaderboard'>
+								<Leaderboard />
+							</GenericSuspense>
+							<GenericSuspense id='eliminated-pilots-view'>
+								<EliminatedPilotsView />
+							</GenericSuspense>
+						</>
+					)}
 			</div>
 
 			<div className='app-legend'>

--- a/frontend/src/common/ViewSelector.css
+++ b/frontend/src/common/ViewSelector.css
@@ -1,0 +1,27 @@
+.view-selector {
+	display: flex;
+	justify-content: space-around;
+	background-color: #1a1a1a;
+	border-bottom: 1px solid #333;
+}
+
+.view-selector button {
+	flex: 1;
+	padding: 8px;
+	min-height: 44px;
+	background: none;
+	color: #fff;
+	border: none;
+	cursor: pointer;
+}
+
+.view-selector button.active {
+	border-bottom: 2px solid #fff;
+	font-weight: bold;
+}
+
+@media (max-width: 599px) {
+	.view-selector {
+		margin-top: 40px;
+	}
+}

--- a/frontend/src/common/ViewSelector.tsx
+++ b/frontend/src/common/ViewSelector.tsx
@@ -16,6 +16,7 @@ export function ViewSelector() {
 		<div className='view-selector' role='tablist'>
 			{panes.map((p) => (
 				<button
+					type='button'
 					key={p.key}
 					role='tab'
 					aria-selected={active === p.key}

--- a/frontend/src/common/ViewSelector.tsx
+++ b/frontend/src/common/ViewSelector.tsx
@@ -1,0 +1,30 @@
+import { useAtom } from 'jotai';
+import { activePaneAtom, DashboardPane } from '../state/viewAtoms.ts';
+import './ViewSelector.css';
+
+const panes: { key: DashboardPane; label: string }[] = [
+	{ key: 'leaderboard', label: 'Leaderboard' },
+	{ key: 'current', label: 'Current Race' },
+	{ key: 'next', label: 'Next Races' },
+	{ key: 'brackets', label: 'Brackets' },
+	{ key: 'eliminated', label: 'Eliminated' },
+];
+
+export function ViewSelector() {
+	const [active, setActive] = useAtom(activePaneAtom);
+	return (
+		<div className='view-selector' role='tablist'>
+			{panes.map((p) => (
+				<button
+					key={p.key}
+					role='tab'
+					aria-selected={active === p.key}
+					className={active === p.key ? 'active' : ''}
+					onClick={() => setActive(p.key)}
+				>
+					{p.label}
+				</button>
+			))}
+		</div>
+	);
+}

--- a/frontend/src/common/index.ts
+++ b/frontend/src/common/index.ts
@@ -4,3 +4,4 @@ export { default as Spinner } from './Spinner.tsx';
 export { default as ErrorBoundary } from './ErrorBoundary.tsx';
 export { default as Legend } from './Legend.tsx';
 export { default as QRCode } from './QRCode.tsx';
+export { ViewSelector } from './ViewSelector.tsx';

--- a/frontend/src/race/CurrentRaceView.tsx
+++ b/frontend/src/race/CurrentRaceView.tsx
@@ -1,0 +1,23 @@
+import { useAtomValue } from 'jotai';
+import { LapsView } from './LapsView.tsx';
+import RaceTime from './RaceTime.tsx';
+import { currentRaceAtom, lastCompletedRaceAtom } from './race-atoms.ts';
+
+export function CurrentRaceView() {
+	const currentRace = useAtomValue(currentRaceAtom);
+	const lastCompletedRace = useAtomValue(lastCompletedRaceAtom);
+	if (!currentRace || (lastCompletedRace && currentRace.id === lastCompletedRace.id)) {
+		return null;
+	}
+	return (
+		<div className='race-box current-race'>
+			<div className='race-header'>
+				<h3>Current Race</h3>
+				<div className='race-timer'>
+					<RaceTime />
+				</div>
+			</div>
+			<LapsView key={currentRace.id} raceId={currentRace.id} />
+		</div>
+	);
+}

--- a/frontend/src/race/NextRacesView.tsx
+++ b/frontend/src/race/NextRacesView.tsx
@@ -1,0 +1,15 @@
+import { useAtomValue } from 'jotai';
+import { NextRaceCompact } from './NextRaceCompact.tsx';
+import { nextRacesAtom } from './race-atoms.ts';
+
+export function NextRacesView() {
+	const nextRaces = useAtomValue(nextRacesAtom);
+	return (
+		<div className='race-box next-races'>
+			<div className='race-header'>
+				<h3>Next Races</h3>
+			</div>
+			{nextRaces.map((race) => <NextRaceCompact key={race.id} raceId={race.id} />)}
+		</div>
+	);
+}

--- a/frontend/src/race/index.ts
+++ b/frontend/src/race/index.ts
@@ -3,6 +3,8 @@
 export { LapsView } from './LapsView.tsx';
 export { RacesContainer } from './RacesContainer.tsx';
 export { default as RaceTime } from './RaceTime.tsx';
+export { CurrentRaceView } from './CurrentRaceView.tsx';
+export { NextRacesView } from './NextRacesView.tsx';
 
 // PB-native race data and atoms
 export { allRacesAtom, currentRaceAtom, currentRaceIndexAtom, lastCompletedRaceAtom, raceDataAtom, raceStatusAtom } from './race-atoms.ts';

--- a/frontend/src/state/index.ts
+++ b/frontend/src/state/index.ts
@@ -1,2 +1,3 @@
 export * from './atoms.ts';
 export * from './hooks.ts';
+export * from './viewAtoms.ts';

--- a/frontend/src/state/viewAtoms.ts
+++ b/frontend/src/state/viewAtoms.ts
@@ -1,0 +1,5 @@
+import { atomWithStorage } from 'jotai/utils';
+
+export type DashboardPane = 'leaderboard' | 'current' | 'next' | 'brackets' | 'eliminated';
+
+export const activePaneAtom = atomWithStorage<DashboardPane>('activePane', 'leaderboard');


### PR DESCRIPTION
## Summary
- add ViewSelector component and persistent active pane atom
- show only selected dashboard section on mobile while keeping desktop layout
- include CurrentRaceView and NextRacesView for mobile-specific panes
- use breakpoint hook for mobile layout styles instead of hard-coded media query

## Testing
- `deno task verify` *(fails: command not found: deno)*

------
https://chatgpt.com/codex/tasks/task_e_68bd0b36f3108321b3772374cfd9bb7a