### PR TITLE
GenericTable: column visibility + grouped chooser + scrollX (mobile-friendly), labels; fix lag/loops

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -47,6 +47,18 @@ The application will be available at `http://localhost:5173`
 - `deno task test` - Run tests
 - `deno task test:watch` - Run tests in watch mode
 
+### Router Devtools
+
+If you see Solid-related warnings in the browser console (e.g., "You appear to have multiple instances of Solid" or "computations created
+outside a createRoot"), they originate from `@tanstack/react-router-devtools` pulling a Solid runtime for its overlay UI. You can disable
+the overlay by setting:
+
+```
+VITE_ROUTER_DEVTOOLS=false
+```
+
+in your `.env` (or leave it unset). To enable explicitly during local debugging, set it to `true`.
+
 ## Project Structure
 
 ```

--- a/frontend/src/common/ColumnChooser.tsx
+++ b/frontend/src/common/ColumnChooser.tsx
@@ -1,0 +1,174 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import type { Column } from './GenericTable.tsx';
+import { useAtom } from 'jotai';
+import { getColumnPrefsAtom } from './columnPrefs.ts';
+
+export function ColumnChooser<TableCtx, RowCtx extends object>(
+	{
+		tableId,
+		columns,
+		label = 'Columns',
+		compact = true,
+		defaultVisible,
+	}: { tableId: string; columns: Array<Column<TableCtx, RowCtx>>; label?: string; compact?: boolean; defaultVisible?: string[] },
+) {
+	// Only recreate the prefs atom if the set of column keys actually changes (not each render)
+	const keySig = useMemo(() => JSON.stringify(defaultVisible ?? columns.map((c) => c.key)), [columns, defaultVisible]);
+	const defaults = useMemo(() => defaultVisible ?? columns.map((c) => c.key), [keySig]);
+	const [visible, setVisible] = useAtom(useMemo(() => getColumnPrefsAtom(tableId, defaults), [tableId, keySig]));
+	const [open, setOpen] = useState(false);
+
+	const allKeys = useMemo(() => columns.map((c) => c.key), [columns]);
+	const labelFor = (c: Column<TableCtx, RowCtx>) => c.label ?? (typeof c.header === 'string' ? c.header : c.key);
+
+	const toggle = (key: string) => {
+		setVisible((prev) => {
+			const set = new Set(prev);
+			if (set.has(key)) set.delete(key);
+			else set.add(key);
+			return Array.from(set);
+		});
+	};
+
+	const setAll = (on: boolean) => {
+		setVisible(on ? allKeys : []);
+	};
+
+	const btnRef = useRef<HTMLButtonElement>(null);
+	const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+
+	useEffect(() => {
+		if (!open) return;
+		const el = btnRef.current;
+		if (!el) return;
+		const rect = el.getBoundingClientRect();
+		const margin = 6;
+		const left = Math.max(8, Math.min(rect.right - 220, globalThis.innerWidth - 228));
+		const top = Math.min(rect.bottom + margin, globalThis.innerHeight - 8);
+		setPos({ top, left });
+	}, [open]);
+
+	useEffect(() => {
+		if (!open) return;
+		const onDown = (e: MouseEvent) => {
+			const chooser = document.getElementById(`col-pop-${tableId}`);
+			if (!chooser) return;
+			if (btnRef.current?.contains(e.target as Node)) return;
+			if (!chooser.contains(e.target as Node)) setOpen(false);
+		};
+		globalThis.addEventListener('mousedown', onDown);
+		return () => globalThis.removeEventListener('mousedown', onDown);
+	}, [open, tableId]);
+
+	const buttonStyle: React.CSSProperties = compact
+		? { width: 28, height: 28, padding: 0, display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }
+		: { padding: '4px 8px' };
+
+	const buttonContent = compact ? <span aria-hidden title={label} style={{ fontSize: 16 }}>☰</span> : <span>{label}</span>;
+
+	// Derive grouped items for the chooser
+	const groups = useMemo(() => {
+		const byGroup = new Map<string, { label: string; keys: string[]; firstIndex: number }>();
+		const singles: Array<{ label: string; key: string; index: number }> = [];
+		columns.forEach((c, index) => {
+			if (c.group) {
+				const existing = byGroup.get(c.group);
+				if (existing) {
+					existing.keys.push(c.key);
+					existing.firstIndex = Math.min(existing.firstIndex, index);
+				} else {
+					byGroup.set(c.group, {
+						label: c.groupLabel ?? c.label ?? 'Group',
+						keys: [c.key],
+						firstIndex: index,
+					});
+				}
+			} else {
+				singles.push({ label: labelFor(c), key: c.key, index });
+			}
+		});
+		const orderedSingles = singles.sort((a, b) => a.index - b.index);
+		const orderedGroups = Array.from(byGroup.values()).sort((a, b) => a.firstIndex - b.firstIndex);
+		return { orderedGroups, orderedSingles };
+	}, [columns]);
+
+	const popover = open && pos && createPortal(
+		<div
+			id={`col-pop-${tableId}`}
+			style={{
+				position: 'fixed',
+				top: pos.top,
+				left: pos.left,
+				zIndex: 1000,
+				background: '#1f2937',
+				border: '1px solid #374151',
+				borderRadius: 6,
+				padding: 8,
+				minWidth: 220,
+				color: '#e5e7eb',
+				boxShadow: '0 8px 24px rgba(0,0,0,0.35)',
+			}}
+		>
+			<div style={{ display: 'flex', gap: 8, marginBottom: 6, justifyContent: 'space-between' }}>
+				<button type='button' onClick={() => setAll(true)} style={{ padding: '2px 6px' }}>All</button>
+				<button type='button' onClick={() => setAll(false)} style={{ padding: '2px 6px' }}>None</button>
+			</div>
+			<div style={{ display: 'grid', gap: 6, maxHeight: 360, overflowY: 'auto' }}>
+				{/* Singles first (preserve table order) */}
+				{groups.orderedSingles.map((s) => {
+					const checked = visible.includes(s.key);
+					return (
+						<label key={s.key} style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
+							<input
+								type='checkbox'
+								checked={checked}
+								onChange={() => toggle(s.key)}
+							/>
+							<span>{s.label}</span>
+						</label>
+					);
+				})}
+
+				{/* Grouped sections next (preserve first-column position order) */}
+				{groups.orderedGroups.map((g, idx) => {
+					const allOn = g.keys.every((k) => visible.includes(k));
+					const someOn = !allOn && g.keys.some((k) => visible.includes(k));
+					return (
+						<label key={`group:${idx}`} style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
+							<input
+								type='checkbox'
+								checked={allOn}
+								ref={(el) => {
+									if (el) el.indeterminate = someOn;
+								}}
+								onChange={() => {
+									setVisible((prev) => {
+										const set = new Set(prev);
+										if (g.keys.every((k) => set.has(k))) {
+											g.keys.forEach((k) => set.delete(k));
+										} else {
+											g.keys.forEach((k) => set.add(k));
+										}
+										return Array.from(set);
+									});
+								}}
+							/>
+							<span>{g.label}</span>
+						</label>
+					);
+				})}
+			</div>
+		</div>,
+		document.body,
+	);
+
+	return (
+		<div style={{ position: 'relative', display: 'inline-block' }}>
+			<button ref={btnRef} type='button' onClick={() => setOpen((v) => !v)} style={buttonStyle} aria-label={label} title={label}>
+				{buttonContent}
+			</button>
+			{popover}
+		</div>
+	);
+}

--- a/frontend/src/common/OverflowFadeCell.tsx
+++ b/frontend/src/common/OverflowFadeCell.tsx
@@ -7,15 +7,22 @@ export function OverflowFadeCell(
 	const ref = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
+		let raf = 0;
 		const checkOverflow = () => {
-			if (ref.current) {
-				const { scrollWidth, clientWidth } = ref.current;
-				setHasOverflow(scrollWidth > clientWidth);
-			}
+			raf = globalThis.requestAnimationFrame(() => {
+				if (ref.current) {
+					const { scrollWidth, clientWidth } = ref.current;
+					const next = scrollWidth > clientWidth;
+					setHasOverflow((prev) => (prev === next ? prev : next));
+				}
+			});
 		};
 		checkOverflow();
 		globalThis.addEventListener('resize', checkOverflow);
-		return () => globalThis.removeEventListener('resize', checkOverflow);
+		return () => {
+			globalThis.cancelAnimationFrame(raf);
+			globalThis.removeEventListener('resize', checkOverflow);
+		};
 	}, [children]);
 
 	return (

--- a/frontend/src/common/columnPrefs.ts
+++ b/frontend/src/common/columnPrefs.ts
@@ -1,0 +1,14 @@
+import { atomWithStorage } from 'jotai/utils';
+import type { PrimitiveAtom } from 'jotai';
+
+// Cache atoms per table so all components share the same instance
+const cache = new Map<string, PrimitiveAtom<string[]>>();
+
+export function getColumnPrefsAtom(tableId: string, defaults: string[]) {
+	const storageKey = `columns:${tableId}`;
+	const existing = cache.get(storageKey);
+	if (existing) return existing as PrimitiveAtom<string[]>;
+	const atom = atomWithStorage<string[]>(storageKey, defaults);
+	cache.set(storageKey, atom);
+	return atom;
+}

--- a/frontend/src/leaderboard/leaderboard-columns.tsx
+++ b/frontend/src/leaderboard/leaderboard-columns.tsx
@@ -135,6 +135,7 @@ export function getLeaderboardColumns(
 		{
 			key: 'position',
 			header: '',
+			label: 'Position',
 			width: 32,
 			cell: function PositionCellInline({ item: { pilotId } }) {
 				const ids = useAtomValue(leaderboardPilotIdsAtom);
@@ -146,6 +147,7 @@ export function getLeaderboardColumns(
 		{
 			key: 'pilot',
 			header: 'Pilot',
+			label: 'Pilot',
 			// Let the Pilot column flex to consume remaining space.
 			// Keep a reasonable minimum so it doesn't collapse.
 			minWidth: 100,
@@ -163,6 +165,7 @@ export function getLeaderboardColumns(
 		{
 			key: 'channel',
 			header: 'Chan',
+			label: 'Channel',
 			width: 52,
 			cell: function ChannelCellInline({ item: { pilotId } }) {
 				const channel = useAtomValue(pilotPreferredChannelAtom(pilotId));
@@ -172,6 +175,7 @@ export function getLeaderboardColumns(
 		{
 			key: 'laps',
 			header: 'Laps',
+			label: 'Lap Count',
 			width: 52,
 			cell: function LapsCellInline({ item: { pilotId } }) {
 				const { current } = useAtomValue(pilotTotalLapsAtom(pilotId));
@@ -181,6 +185,7 @@ export function getLeaderboardColumns(
 		{
 			key: 'holeshot',
 			header: 'Hole shot',
+			label: 'Holeshot',
 			width: 64,
 			cell: function HoleshotCell({ item: { pilotId } }) {
 				return <RenderTimeCell metricAtom={pilotHoleshotAtom(pilotId)} />;
@@ -189,6 +194,7 @@ export function getLeaderboardColumns(
 		{
 			key: 'top-lap',
 			header: 'Top Lap',
+			label: 'Best Lap',
 			width: 72,
 			cell: function BestLapCell({ item: { pilotId } }) {
 				return <RenderTimeCell metricAtom={pilotBestLapAtom(pilotId)} />;
@@ -198,6 +204,7 @@ export function getLeaderboardColumns(
 			? [{
 				key: 'consec',
 				header: () => `Top ${ctx.consecutiveLaps} Consec`,
+				label: `Top ${ctx.consecutiveLaps} Consecutive`,
 				width: 72,
 				cell: function ConsecCell({ item }) {
 					const { pilotId } = item;
@@ -208,6 +215,7 @@ export function getLeaderboardColumns(
 		{
 			key: 'fastest-race',
 			header: 'Fastest Race',
+			label: 'Fastest Total',
 			width: 72,
 			cell: function TotalRaceCell({ item }) {
 				const { pilotId } = item;
@@ -217,6 +225,7 @@ export function getLeaderboardColumns(
 		{
 			key: 'next',
 			header: 'Next Race In',
+			label: 'Next Race',
 			width: 96,
 			cell: function NextRaceStatusCellInline({ item }) {
 				const { pilotId } = item;

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -3,6 +3,8 @@ import { TanStackRouterDevtools } from '@tanstack/react-router-devtools';
 
 type RouterContext = Record<PropertyKey, never>;
 
+const enableRouterDevtools = import.meta.env.DEV && (import.meta.env.VITE_ROUTER_DEVTOOLS === 'true');
+
 export const Route = createRootRouteWithContext<RouterContext>()({
 	component: () => (
 		<>
@@ -15,7 +17,7 @@ export const Route = createRootRouteWithContext<RouterContext>()({
 			<main>
 				<Outlet />
 			</main>
-			{import.meta.env.DEV && <TanStackRouterDevtools position='bottom-right' />}
+			{enableRouterDevtools && <TanStackRouterDevtools position='bottom-right' />}
 		</>
 	),
 });


### PR DESCRIPTION
Summary
- Adds column visibility controls with persistence and smooth spring animations on mobile.
- Introduces a small icon-based Column Chooser that opens as a portal popover (not clipped by containers).
- Supports grouped columns in the picker (e.g., all L1..Ln as a single "Laps" toggle; Holeshot stays separate).
- Adds human-friendly Column.label separate from in-table header text (which can stay abbreviated).

Key Changes
- GenericTable
  - New props: `visibleColumns`, `scrollX`.
  - Adds `data-col` attributes on header/cells.
  - Column type gains `label?`, `group?`, `groupLabel?` for picker UX.
- Column Chooser
  - Reusable popover with checkbox list, grouping, All/None, outside-click close.
  - Compact button trigger (☰) by default; uses portal to avoid clipping.
  - Shares state with tables via a cached `atomWithStorage` so updates reflect instantly.
- Leaderboard & Laps
  - Wire in Column Chooser and pass `visibleColumns` + `scrollX` to `GenericTable`.
  - Leaderboard: add descriptive labels.
  - Laps: memoize columns for stability; group L1..Ln under "Laps"; keep Holeshot separate; add labels.
- Devtools
  - Router devtools overlay now gated by `VITE_ROUTER_DEVTOOLS=true` to avoid Solid warnings unless explicitly enabled.

Fixes
- Resolves the lag where column changes only appeared after switching tabs (shared atom instance + memoized columns).
- Prevents maximum update depth loops by stabilizing atoms and guarding overflow checks.

Acceptance
- Verified with `deno task verify` (fmt, lint, type check).

Closes #7